### PR TITLE
Bayeux Cleanup and Testing

### DIFF
--- a/Tests/Bayeux/BayeuxClientTest.php
+++ b/Tests/Bayeux/BayeuxClientTest.php
@@ -9,6 +9,7 @@
 namespace AE\SalesforceRestSdk\Tests\Bayeux;
 
 use AE\SalesforceRestSdk\AuthProvider\OAuthProvider;
+use AE\SalesforceRestSdk\AuthProvider\SoapProvider;
 use AE\SalesforceRestSdk\Bayeux\BayeuxClient;
 use AE\SalesforceRestSdk\Bayeux\ChannelInterface;
 use AE\SalesforceRestSdk\Bayeux\Consumer;
@@ -50,7 +51,7 @@ class BayeuxClientTest extends TestCase
             function (ChannelInterface $channel, Message $message) use ($name, &$consumer) {
                 $this->assertTrue($message->isSuccessful());
                 $this->assertFalse($this->client->isDisconnected());
-                $client   = new Client(['base_uri' => getenv('SF_URL')]);
+                $client   = new Client(['base_uri' => $this->client->getAuthProvider()->getInstanceUrl()]);
                 $response = $client->post(
                     'services/data/v43.0/sobjects/Account',
                     [
@@ -86,7 +87,7 @@ class BayeuxClientTest extends TestCase
                         $this->client->disconnect();
                     }
 
-                    $client   = new Client(['base_uri' => getenv('SF_URL')]);
+                    $client   = new Client(['base_uri' => $this->client->getAuthProvider()->getInstanceUrl()]);
                     $response = $client->delete(
                         'services/data/v43.0/sobjects/Account/'.$sobject->Id,
                         [

--- a/src/Bayeux/BayeuxClient.php
+++ b/src/Bayeux/BayeuxClient.php
@@ -60,7 +60,7 @@ class BayeuxClient
 
     public const VERSION            = '1.0';
     public const MINIMUM_VERSION    = '1.0';
-    public const SALESFORCE_VERSION = '43.0';
+    public const SALESFORCE_VERSION = '44.0';
 
     /**
      * @var Client
@@ -115,7 +115,6 @@ class BayeuxClient
     /**
      * BayeuxClient constructor.
      *
-     * @param string $url
      * @param AbstractClientTransport $transport
      * @param AuthProviderInterface $authProvider
      * @param LoggerInterface|null $logger
@@ -507,7 +506,8 @@ class BayeuxClient
             $newMessages = $this->transport->send(
                 $messages,
                 function (RequestInterface $request) {
-                    return $request->withAddedHeader('Authorization', $this->authProvider->authorize());
+                    $this->authProvider->authorize();
+                    return $request->withAddedHeader('Authorization', 'OAuth '. $this->authProvider->getToken());
                 }
             );
         } catch (SessionExpiredOrInvalidException $e) {

--- a/src/Bayeux/Channel.php
+++ b/src/Bayeux/Channel.php
@@ -38,15 +38,6 @@ class Channel implements ChannelInterface
 
     public function notifyMessageListeners(Message $message)
     {
-        // Attempt to set the SObject type
-        if (!$this->isMeta() && null !== $message->getData()) {
-            $data = $message->getData();
-
-            if (null !== $data->getSobject() && null !== $data->getEvent()->getType()) {
-                $data->getSobject()->setType($data->getEvent()->getType());
-            }
-        }
-
         /** @var ConsumerInterface[] $subscribers */
         $subscribers = $this->subscribers->getValues();
 


### PR DESCRIPTION
When using the SoapProvider, the Bayeux client successfully handshakes but received a 403::Unknown Client error when making the connect call. This is a know issue with Salesforce. The OAuthProvider works as intended.