### PR TITLE
Fix issue with line breaks in a csv column

### DIFF
--- a/Tests/Psr7/CsvStreamTest.php
+++ b/Tests/Psr7/CsvStreamTest.php
@@ -16,13 +16,13 @@ class CsvStreamTest extends TestCase
 {
     public function testRead()
     {
-        $testLine = '"Item 1","Item 2","This is a longer'.PHP_EOL.'multiline field","Last Field"';
+        $testLine = '"Item 1","Item 2","This is a longer'.PHP_EOL.'multiline field","Last Field"'.PHP_EOL;
         $stream = stream_for($testLine);
         $csv = new CsvStream($stream);
 
         $line = CsvStream::readline($stream);
 
-        $this->assertEquals($testLine, $line);
+        $this->assertEquals(rtrim($testLine, "\n"), $line);
 
         $stream->rewind();
 

--- a/Tests/Psr7/CsvStreamTest.php
+++ b/Tests/Psr7/CsvStreamTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 10/31/18
+ * Time: 10:12 AM
+ */
+
+namespace AE\SalesforceRestSdk\Tests\Psr7;
+
+use AE\SalesforceRestSdk\Psr7\CsvStream;
+use function GuzzleHttp\Psr7\stream_for;
+use PHPUnit\Framework\TestCase;
+
+class CsvStreamTest extends TestCase
+{
+    public function testRead()
+    {
+        $testLine = '"Item 1","Item 2","This is a longer'.PHP_EOL.'multiline field","Last Field"';
+        $stream = stream_for($testLine);
+        $csv = new CsvStream($stream);
+
+        $line = CsvStream::readline($stream);
+
+        $this->assertEquals($testLine, $line);
+
+        $stream->rewind();
+
+        $row = $csv->read();
+
+        $this->assertEquals(
+            [
+                'Item 1',
+                'Item 2',
+                'This is a longer'.PHP_EOL.'multiline field',
+                'Last Field'
+            ],
+            $row
+        );
+    }
+}

--- a/src/Psr7/CsvStream.php
+++ b/src/Psr7/CsvStream.php
@@ -121,7 +121,7 @@ class CsvStream implements StreamInterface
             $escFlag = $byte === $escape && !$escFlag;
         }
 
-        return $buffer;
+        return rtrim($buffer, "\n");
     }
 
     public function read($length = 0, string $delimiter = ",", string $enclosure = '"', string $escape = "\\")


### PR DESCRIPTION
Line breaks within the the value of a CSV field were causing truncated line reads and therefore causing data mapping conditions on bulk imports.