### PR TITLE
Fix issue with line breaks in a csv column (#19)

### DIFF
--- a/Tests/Psr7/CsvStreamTest.php
+++ b/Tests/Psr7/CsvStreamTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 10/31/18
+ * Time: 10:12 AM
+ */
+
+namespace AE\SalesforceRestSdk\Tests\Psr7;
+
+use AE\SalesforceRestSdk\Psr7\CsvStream;
+use function GuzzleHttp\Psr7\stream_for;
+use PHPUnit\Framework\TestCase;
+
+class CsvStreamTest extends TestCase
+{
+    public function testRead()
+    {
+        $testLine = '"Item 1","Item 2","This is a longer'.PHP_EOL.'multiline field","Last Field"'.PHP_EOL;
+        $stream = stream_for($testLine);
+        $csv = new CsvStream($stream);
+
+        $line = CsvStream::readline($stream);
+
+        $this->assertEquals(rtrim($testLine, "\n"), $line);
+
+        $stream->rewind();
+
+        $row = $csv->read();
+
+        $this->assertEquals(
+            [
+                'Item 1',
+                'Item 2',
+                'This is a longer'.PHP_EOL.'multiline field',
+                'Last Field'
+            ],
+            $row
+        );
+    }
+}

--- a/src/Psr7/CsvStream.php
+++ b/src/Psr7/CsvStream.php
@@ -79,17 +79,58 @@ class CsvStream implements StreamInterface
         return $this->stream->isReadable();
     }
 
+    /**
+     * Similar to \GuzzleHttp\Psr7\readline, but with some helper flags
+     * @param StreamInterface $stream
+     * @param int|null $maxLength
+     * @param string $enclosure
+     * @param string $escape
+     *
+     * @return string
+     */
+    public static function readline(
+        StreamInterface $stream,
+        ?int $maxLength = null,
+        string $enclosure = '"',
+        string $escape = "\\"
+    ) {
+        $buffer = '';
+        $size = 0;
+        $encFlag = false;
+        $escFlag = false;
+
+        if ($stream instanceof CsvStream) {
+            throw new \InvalidArgumentException("Cannot use CsvStream::readline on a CsvStream.");
+        }
+
+        while (!$stream->eof()) {
+            if (null == ($byte = $stream->read(1))) {
+                return $buffer;
+            }
+
+            $buffer .= $byte;
+
+            if ($byte === $enclosure) {
+                $encFlag = !$encFlag;
+            }
+
+            if ((!$encFlag && !$escFlag && $byte === "\n") || ++$size === $maxLength - 1) {
+                break;
+            }
+
+            $escFlag = $byte === $escape && !$escFlag;
+        }
+
+        return rtrim($buffer, "\n");
+    }
+
     public function read($length = 0, string $delimiter = ",", string $enclosure = '"', string $escape = "\\")
     {
         if ($length < 0) {
             throw new \RuntimeException("The length cannot be a negative number,");
         }
 
-        $line = \GuzzleHttp\Psr7\readline($this->stream, $length > 0 ? $length : null);
-
-        if (false == $line) {
-            return false;
-        }
+        $line = self::readline($this->stream, $length > 0 ? $length : null, $enclosure, $escape);
 
         return str_getcsv($line, $delimiter, $enclosure, $escape);
     }


### PR DESCRIPTION
* Fix issue with line breaks in a csv column

* Ensure line breaks are removed from the end of the read line. Leaving them will cause issues with str_getcsv