### PR TITLE
Issue-33: made the replay extension work

### DIFF
--- a/Tests/Bayeux/Extension/ReplayExtensionTest.php
+++ b/Tests/Bayeux/Extension/ReplayExtensionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace AE\SalesforceRestSdk\Tests\Bayeux\Extension;
+
+use AE\SalesforceRestSdk\Bayeux\Extension\ReplayExtension;
+use AE\SalesforceRestSdk\Bayeux\Message;
+use PHPUnit\Framework\TestCase;
+
+class ReplayExtensionTest extends TestCase
+{
+    public function testPrepareSend(): void
+    {
+        $channelId = 'foo';
+        $replayId = 42;
+        $extension = new ReplayExtension($channelId, $replayId);
+
+        $message = new Message();
+        $message->setSubscription('foo');
+        $extension->prepareSend($message);
+
+        $this->assertEquals(['replay' => ['foo' => 42]], $message->getExt());
+    }
+
+    public function testPrepareSend_WithUnsupportedChannelId(): void
+    {
+        $channelId = 'foo';
+        $replayId = 42;
+        $extension = new ReplayExtension($channelId, $replayId);
+
+        $message = new Message();
+        $message->setSubscription('bar');
+        $extension->prepareSend($message);
+
+        $this->assertNull($message->getExt());
+    }
+
+    public function testPrepareSend_WithPreviousExtensionSet(): void
+    {
+        $channelId = 'foo';
+        $replayId = 42;
+        $extension = new ReplayExtension($channelId, $replayId);
+
+        $message = new Message();
+        $message->setSubscription('foo');
+        $message->setExt(['foo' => 'bar']);
+        $extension->prepareSend($message);
+
+        $this->assertEquals(['foo' => 'bar', 'replay' => ['foo' => 42]], $message->getExt());
+    }
+}

--- a/src/Bayeux/Extension/ReplayExtension.php
+++ b/src/Bayeux/Extension/ReplayExtension.php
@@ -22,8 +22,14 @@ class ReplayExtension implements ExtensionInterface
      */
     private $replayId = self::REPLAY_NEWEST;
 
-    public function __construct(int $replayId = self::REPLAY_NEWEST)
+    /**
+     * @var string
+     */
+    private $channelId;
+
+    public function __construct(string $channel, int $replayId = self::REPLAY_NEWEST)
     {
+        $this->channelId = $channel;
         $this->replayId = $replayId;
     }
 
@@ -40,9 +46,9 @@ class ReplayExtension implements ExtensionInterface
      */
     public function prepareSend(Message $message): void
     {
-        if ($message->getChannel() === ChannelInterface::META_CONNECT) {
-            $ext                   = $message->getExt() ?: [];
-            $ext[$this->getName()] = $this->replayId;
+        if ($message->getSubscription() === $this->channelId) {
+            $ext = $message->getExt() ?: [];
+            $ext[$this->getName()] = [$this->channelId => $this->replayId];
 
             $message->setExt($ext);
         }


### PR DESCRIPTION
We investigated why the replay extension did not work out of the box and came across the examples in java and javascript:
https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/code_sample_generic_vfp_walkthrough.htm
and 
https://github.com/developerforce/StreamingReplayClientExtensions/blob/master/javascript/cometdReplayExtension.js

and we noticed the extension is set to other channels (e.g. /event/subscribe/) and the message body also contains the channel id we would like to subscribe to ("ext : { "replay" : { CHANNEL : REPLAY_VALUE }}".

Resources: https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/using_streaming_api_durability.htm?search_text=replay

We are aware this could be a BC change but think their shouldn't be too many folks having implemented this extension because it does not seem to work. If so, I'd like to hear about their opinion about this and how they made it work... 