### PR TITLE
Curiosity26/cache improvements (#39)

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -11,7 +11,6 @@
       <path value="$PROJECT_DIR$/vendor/doctrine/instantiator" />
       <path value="$PROJECT_DIR$/vendor/psr/http-message" />
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
-      <path value="$PROJECT_DIR$/vendor/symfony/expression-language" />
       <path value="$PROJECT_DIR$/vendor/psr/cache" />
       <path value="$PROJECT_DIR$/vendor/jms/parser-lib" />
       <path value="$PROJECT_DIR$/vendor/psr/log" />
@@ -50,6 +49,10 @@
       <path value="$PROJECT_DIR$/vendor/guzzlehttp/promises" />
       <path value="$PROJECT_DIR$/vendor/guzzlehttp/psr7" />
       <path value="$PROJECT_DIR$/vendor/guzzlehttp/guzzle" />
+      <path value="$PROJECT_DIR$/vendor/symfony/contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/var-exporter" />
+      <path value="$PROJECT_DIR$/vendor/ralouphie/getallheaders" />
+      <path value="$PROJECT_DIR$/vendor/symfony/expression-language" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />

--- a/.idea/salesforce-rest-sdk.iml
+++ b/.idea/salesforce-rest-sdk.iml
@@ -33,6 +33,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/http-message" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/log" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/simple-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/ralouphie/getallheaders" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/ramsey/uuid" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/comparator" />
@@ -46,8 +47,10 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/resource-operations" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/version" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/cache" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/contracts" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/expression-language" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-ctype" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/var-exporter" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
     </content>

--- a/Tests/AuthProvider/CachedOAuthProviderTest.php
+++ b/Tests/AuthProvider/CachedOAuthProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 12:15 PM
+ */
+
+namespace AE\SalesforceRestSdk\Tests\AuthProvider;
+
+use AE\SalesforceRestSdk\AuthProvider\CachedOAuthProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class CachedOAuthProviderTest extends TestCase
+{
+    public function testAuthorize()
+    {
+        $adapter = new ArrayAdapter();
+        $provider = new CachedOAuthProvider(
+            $adapter,
+            getenv("SF_CLIENT_ID"),
+            getenv("SF_CLIENT_SECRET"),
+            getenv("SF_LOGIN_URL"),
+            getenv("SF_USER"),
+            getenv("SF_PASS")
+        );
+
+        $initHeader = $provider->authorize();
+        $this->assertGreaterThan(0, strlen($initHeader));
+
+        $provider2 = new CachedOAuthProvider(
+            $adapter,
+            getenv("SF_CLIENT_ID"),
+            getenv("SF_CLIENT_SECRET"),
+            getenv("SF_LOGIN_URL"),
+            getenv("SF_USER"),
+            getenv("SF_PASS")
+        );
+
+        $nextHeader = $provider2->authorize();
+
+        $this->assertEquals($initHeader, $nextHeader);
+    }
+}

--- a/Tests/AuthProvider/CachedSoapProviderTest.php
+++ b/Tests/AuthProvider/CachedSoapProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 12:24 PM
+ */
+
+namespace AE\SalesforceRestSdk\Tests\AuthProvider;
+
+use AE\SalesforceRestSdk\AuthProvider\CachedSoapProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class CachedSoapProviderTest extends TestCase
+{
+    public function testAuthorize()
+    {
+        $adapter = new ArrayAdapter();
+        $provider = new CachedSoapProvider(
+            $adapter,
+            getenv("SF_USER"),
+            getenv("SF_PASS"),
+            getenv("SF_LOGIN_URL")
+        );
+
+        $initHeader = $provider->authorize();
+        $this->assertGreaterThan(0, strlen($initHeader));
+
+        $provider2 = new CachedSoapProvider(
+            $adapter,
+            getenv("SF_USER"),
+            getenv("SF_PASS"),
+            getenv("SF_LOGIN_URL")
+        );
+
+        $nextHeader = $provider2->authorize();
+        $this->assertEquals($initHeader, $nextHeader);
+    }
+}

--- a/Tests/Bayeux/Extension/CachedReplayExtensionTest.php
+++ b/Tests/Bayeux/Extension/CachedReplayExtensionTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 12:50 PM
+ */
+
+namespace AE\SalesforceRestSdk\Tests\Bayeux\Extensions;
+
+use AE\SalesforceRestSdk\Bayeux\Channel;
+use AE\SalesforceRestSdk\Bayeux\ChannelInterface;
+use AE\SalesforceRestSdk\Bayeux\Extension\CachedReplayExtension;
+use AE\SalesforceRestSdk\Bayeux\Message;
+use AE\SalesforceRestSdk\Bayeux\Salesforce\Event;
+use AE\SalesforceRestSdk\Bayeux\Salesforce\StreamingData;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class CachedReplayExtensionTest extends TestCase
+{
+    public function testOutgoing()
+    {
+        $adapter = new ArrayAdapter();
+        $channel = new Channel(ChannelInterface::META_SUBSCRIBE);
+        $ext     = new CachedReplayExtension($adapter);
+        $now     = new \DateTime();
+
+        $channel->addExtension($ext);
+
+        $this->assertEquals(CachedReplayExtension::REPLAY_NEWEST, $ext->getReplayIdForChannel('/topic/cool_topic'));
+
+        $key  = "REPLAY_EXT__topic_cool_topic";
+        $item = $adapter->getItem($key);
+        $item->set(
+            [
+                'replayId'  => 500,
+                'timestamp' => $now->format(\DATE_ISO8601),
+            ]
+        );
+        $item->expiresAfter(new \DateInterval('P1D'));
+        $adapter->save($item);
+
+        $message = new Message();
+        $message->setChannel(ChannelInterface::META_SUBSCRIBE)
+                ->setSubscription('/topic/cool_topic')
+        ;
+
+        $channel->prepareOutgoingMessage($message);
+
+        $this->assertEquals(
+            [
+                CachedReplayExtension::NAME => [
+                    '/topic/cool_topic' => 500,
+                ],
+            ],
+            $message->getExt()
+        );
+
+        $item->expiresAt($now->sub(new \DateInterval('P1D')));
+        $adapter->save($item);
+
+        $channel->prepareOutgoingMessage($message);
+
+        $this->assertEquals(
+            [
+                CachedReplayExtension::NAME => [
+                    '/topic/cool_topic' => CachedReplayExtension::REPLAY_NEWEST,
+                ],
+            ],
+            $message->getExt()
+        );
+    }
+
+    public function testIncoming()
+    {
+        $adapter = new ArrayAdapter();
+        $channel = new Channel('/topic/cool_topic');
+        $ext     = new CachedReplayExtension($adapter);
+        $now     = new \DateTimeImmutable("now", new \DateTimeZone("UTC"));
+        $key     = "REPLAY_EXT__topic_cool_topic";
+
+        $channel->addExtension($ext);
+
+        $this->assertEquals(CachedReplayExtension::REPLAY_NEWEST, $ext->getReplayIdForChannel('/topic/cool_topic'));
+
+        $event = new Event();
+        $event->setReplayId(500);
+
+        $data = new StreamingData();
+        $data->setEvent($event);
+
+        $message = new Message();
+        $message->setChannel('/topic/cool_topic')
+                ->setData($data)
+                ->setTimestamp($now)
+        ;
+
+        $channel->notifyMessageListeners($message);
+
+        $this->assertEquals(500, $ext->getReplayIdForChannel('/topic/cool_topic'));
+        $this->assertTrue($adapter->hasItem($key));
+
+        $item = $adapter->getItem($key);
+        $value = $item->get();
+
+        $this->assertEquals($now->format(\DATE_ISO8601), $value['timestamp']);
+        $this->assertEquals(500, $value['replayId']);
+    }
+}

--- a/Tests/Bayeux/Extension/ReplayExtensionTest.php
+++ b/Tests/Bayeux/Extension/ReplayExtensionTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 12:30 PM
+ */
+
+namespace AE\SalesforceRestSdk\Tests\Bayeux\Extensions;
+
+use AE\SalesforceRestSdk\Bayeux\Channel;
+use AE\SalesforceRestSdk\Bayeux\ChannelInterface;
+use AE\SalesforceRestSdk\Bayeux\Extension\ReplayExtension;
+use AE\SalesforceRestSdk\Bayeux\Message;
+use AE\SalesforceRestSdk\Bayeux\Salesforce\Event;
+use AE\SalesforceRestSdk\Bayeux\Salesforce\StreamingData;
+use PHPUnit\Framework\TestCase;
+
+class ReplayExtensionTest extends TestCase
+{
+    public function testOutgoing()
+    {
+        $channel = new Channel(ChannelInterface::META_SUBSCRIBE);
+        $ext     = new ReplayExtension();
+
+        $channel->addExtension($ext);
+
+        $message = new Message();
+        $message->setChannel(ChannelInterface::META_SUBSCRIBE)
+                ->setSubscription('/topic/cool_topic')
+        ;
+
+        $channel->prepareOutgoingMessage($message);
+
+        $this->assertEquals(
+            [
+                ReplayExtension::NAME => [
+                    '/topic/cool_topic' => ReplayExtension::REPLAY_NEWEST,
+                ],
+            ],
+            $message->getExt()
+        );
+    }
+
+    public function testIncoming()
+    {
+        $channel = new Channel('/topic/cool_topic');
+        $ext = new ReplayExtension();
+        $channel->addExtension($ext);
+
+        $event = new Event();
+        $event->setReplayId(500);
+
+        $data = new StreamingData();
+        $data->setEvent($event);
+
+        $message = new Message();
+        $message->setChannel('/topic/cool_topic')
+            ->setData($data)
+            ;
+
+        $channel->notifyMessageListeners($message);
+
+        $this->assertEquals(500, $ext->getReplayIdForChannel('/topic/cool_topic'));
+    }
+}

--- a/Tests/Rest/GenericEventClientTest.php
+++ b/Tests/Rest/GenericEventClientTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 2:31 PM
+ */
+
+namespace AE\SalesforceRestSdk\Tests\Rest;
+
+use AE\SalesforceRestSdk\AuthProvider\OAuthProvider;
+use AE\SalesforceRestSdk\Model\Rest\GenericEvent;
+use AE\SalesforceRestSdk\Model\SObject;
+use AE\SalesforceRestSdk\Rest\GenericEventClient;
+use AE\SalesforceRestSdk\Rest\SObject\Client;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class GenericEventClientTest extends TestCase
+{
+    /**
+     * @var Client
+     */
+    private $sObjectClient;
+
+    /**
+     * @var SObject
+     */
+    private $channel;
+
+    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        $restClient    = new \AE\SalesforceRestSdk\Rest\Client(
+            new OAuthProvider(
+                getenv("SF_CLIENT_ID"),
+                getenv("SF_CLIENT_SECRET"),
+                getenv("SF_LOGIN_URL"),
+                getenv("SF_USER"),
+                getenv("SF_PASS")
+            )
+        );
+        $this->sObjectClient = $restClient->getSObjectClient();
+
+        $this->channel = new SObject(
+            [
+                'name' => '/u/test/TestChannel',
+            ]
+        );
+
+        $this->sObjectClient->persist('StreamingChannel', $this->channel);
+    }
+
+    public function testGenericEvents()
+    {
+
+        $adapter       = new ArrayAdapter();
+        $client        = new GenericEventClient($adapter, $this->sObjectClient);
+
+        $this->assertEquals($this->channel->Id, $client->getStreamingChannelId('/u/test/TestChannel'));
+        $cache = $adapter->getItem('GENERIC_EVENTS')->get();
+        $this->assertEquals($this->channel->Id, $cache['/u/test/TestChannel']);
+
+        $event = new GenericEvent();
+        $event->setPayload("Testing the Event");
+
+        $res = $client->sendEvent('/u/test/TestChannel', $event);
+        $this->assertNotNull($res);
+        $this->assertGreaterThanOrEqual(0, $res->getFanoutCount());
+    }
+
+    protected function tearDown()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        $this->sObjectClient->remove('StreamingChannel', $this->channel);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         "jms/serializer": "^1.13",
         "ramsey/uuid": "^3.8",
         "doctrine/collections": "^1.5",
-        "symfony/expression-language": "^4.1"
+        "symfony/cache": "~3.4|~4.0",
+        "psr/log": "^1.1",
+        "symfony/expression-language": "^4.2"
     },
     "license": "proprietary",
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3eab5f8da8532ccfb96fe5fe6e43090",
+    "content-hash": "09c5d6065205eccb8789cde5db36ad29",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -367,32 +367,33 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+                "reference": "9f83dded91781a01c63574e387eaa769be769115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -422,26 +423,27 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "jms/metadata",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/metadata.git",
-                "reference": "6a06970a10e0a532fb52d3959547123b84a3b3ab"
+                "reference": "e5854ab1aa643623dc64adde718a8eec32b957a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/6a06970a10e0a532fb52d3959547123b84a3b3ab",
-                "reference": "6a06970a10e0a532fb52d3959547123b84a3b3ab",
+                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/e5854ab1aa643623dc64adde718a8eec32b957a8",
+                "reference": "e5854ab1aa643623dc64adde718a8eec32b957a8",
                 "shasum": ""
             },
             "require": {
@@ -464,9 +466,13 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache-2.0"
+                "MIT"
             ],
             "authors": [
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                },
                 {
                     "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com"
@@ -479,7 +485,7 @@
                 "xml",
                 "yaml"
             ],
-            "time": "2016-12-05T10:18:33+00:00"
+            "time": "2018-10-26T12:40:10+00:00"
         },
         {
             "name": "jms/parser-lib",
@@ -841,16 +847,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -884,7 +890,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -933,6 +939,46 @@
                 "simple-cache"
             ],
             "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2016-02-11T07:05:27+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -1018,41 +1064,49 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v4.1.4",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "b8440ff4635c6631aca21a09ab72e0b7e3a6cb7a"
+                "reference": "b5c650406953f2f44a37c4f3ac66152fafc22c66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/b8440ff4635c6631aca21a09ab72e0b7e3a6cb7a",
-                "reference": "b8440ff4635c6631aca21a09ab72e0b7e3a6cb7a",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/b5c650406953f2f44a37c4f3ac66152fafc22c66",
+                "reference": "b5c650406953f2f44a37c4f3ac66152fafc22c66",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "psr/cache": "~1.0",
                 "psr/log": "~1.0",
-                "psr/simple-cache": "^1.0"
+                "psr/simple-cache": "^1.0",
+                "symfony/contracts": "^1.0",
+                "symfony/var-exporter": "^4.2"
             },
             "conflict": {
+                "doctrine/dbal": "<2.5",
+                "symfony/dependency-injection": "<3.4",
                 "symfony/var-dumper": "<3.4"
             },
             "provide": {
                 "psr/cache-implementation": "1.0",
-                "psr/simple-cache-implementation": "1.0"
+                "psr/simple-cache-implementation": "1.0",
+                "symfony/cache-contracts-implementation": "1.0"
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
                 "doctrine/cache": "~1.6",
-                "doctrine/dbal": "~2.4",
-                "predis/predis": "~1.0"
+                "doctrine/dbal": "~2.5",
+                "predis/predis": "~1.1",
+                "symfony/config": "~4.2",
+                "symfony/dependency-injection": "~3.4|~4.1",
+                "symfony/var-dumper": "^4.1.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1083,30 +1137,99 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2018-08-27T09:36:56+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
-            "name": "symfony/expression-language",
-            "version": "v4.1.4",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/expression-language.git",
-                "reference": "065bba63c61c96fd2d4fbd01b28de058e6f8779a"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/065bba63c61c96fd2d4fbd01b28de058e6f8779a",
-                "reference": "065bba63c61c96fd2d4fbd01b28de058e6f8779a",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/cache": "~3.4|~4.0"
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "a69b153996a13ffdb05395e8724c7217a8448e9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/a69b153996a13ffdb05395e8724c7217a8448e9e",
+                "reference": "a69b153996a13ffdb05395e8724c7217a8448e9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/contracts": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1133,11 +1256,11 @@
             ],
             "description": "Symfony ExpressionLanguage Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T09:10:45+00:00"
+            "time": "2019-01-16T20:31:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1180,7 +1303,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1192,6 +1315,66 @@
                 "portable"
             ],
             "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "d8bf4424c232b55f4c1816037d3077a89258557e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/d8bf4424c232b55f4c1816037d3077a89258557e",
+                "reference": "d8bf4424c232b55f4c1816037d3077a89258557e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^4.1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "time": "2019-01-16T20:35:37+00:00"
         }
     ],
     "packages-dev": [
@@ -1562,16 +1745,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.7",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/865662550c384bc1db7e51d29aeda1c2c161d69a",
-                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
@@ -1582,7 +1765,7 @@
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
@@ -1595,7 +1778,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1621,7 +1804,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-06-01T07:51:50+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1716,16 +1899,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.0.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
                 "shasum": ""
             },
             "require": {
@@ -1737,7 +1920,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -1761,20 +1944,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-02-01T13:07:23+00:00"
+            "time": "2019-02-20T10:12:59+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
                 "shasum": ""
             },
             "require": {
@@ -1810,20 +1993,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-02-01T13:16:43+00:00"
+            "time": "2018-10-30T05:52:18+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.3.5",
+            "version": "7.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7b331efabbb628c518c408fdfcaf571156775de2"
+                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7b331efabbb628c518c408fdfcaf571156775de2",
-                "reference": "7b331efabbb628c518c408fdfcaf571156775de2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
+                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
                 "shasum": ""
             },
             "require": {
@@ -1844,11 +2027,11 @@
                 "phpunit/php-timer": "^2.0",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
             },
             "conflict": {
@@ -1868,7 +2051,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.3-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -1894,7 +2077,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-08T15:14:29+00:00"
+            "time": "2019-02-18T09:24:50+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2007,23 +2190,23 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "366541b989927187c4ca70490a35615d3fef2dce"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/366541b989927187c4ca70490a35615d3fef2dce",
-                "reference": "366541b989927187c4ca70490a35615d3fef2dce",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0",
+                "phpunit/phpunit": "^7.5 || ^8.0",
                 "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
@@ -2059,32 +2242,35 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2018-06-10T07:54:39+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2109,7 +2295,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-02-01T05:27:49+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2376,25 +2562,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2414,7 +2600,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2501,20 +2687,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -2547,7 +2734,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/src/AuthProvider/CachedOAuthProvider.php
+++ b/src/AuthProvider/CachedOAuthProvider.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 11:40 AM
+ */
+
+namespace AE\SalesforceRestSdk\AuthProvider;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+use Psr\Cache\InvalidArgumentException;
+
+class CachedOAuthProvider extends OAuthProvider
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $adapter;
+
+    public function __construct(
+        CacheItemPoolInterface $adapter,
+        string $clientId,
+        string $clientSecret,
+        string $url,
+        ?string $username,
+        ?string $password,
+        string $grantType = self::GRANT_PASSWORD,
+        ?string $redirectUri = null,
+        ?string $code = null
+    ) {
+        parent::__construct($clientId, $clientSecret, $url, $username, $password, $grantType, $redirectUri, $code);
+        $this->adapter = $adapter;
+        $this->logger  = new NullLogger();
+    }
+
+    public function authorize($reauth = false): string
+    {
+        $oldToken = null;
+
+        try {
+            if (!$reauth && null === $this->token && $this->adapter->hasItem($this->clientId)) {
+                $values             = $this->adapter->getItem($this->clientId)->get();
+                $this->token        = $oldToken = $values['token'];
+                $this->tokenType    = $values['tokenType'];
+                $this->refreshToken = $values['refreshToken'];
+                $this->instanceUrl  = $values['instanceUrl'];
+                $this->identityUrl  = $values['identityUrl'];
+                $this->isAuthorized = $values['isAuthorized'];
+            }
+        } catch (InvalidArgumentException $e) {
+            $this->logger->error($e->getMessage());
+        }
+
+        try {
+            $header = parent::authorize($reauth);
+
+            if ($this->token !== $oldToken) {
+                $item = $this->adapter->getItem($this->clientId);
+                $item->set(
+                    [
+                        'token'        => $this->token,
+                        'tokenType'    => $this->tokenType,
+                        'refreshToken' => $this->refreshToken,
+                        'instanceUrl'  => $this->instanceUrl,
+                        'identityUrl'  => $this->identityUrl,
+                        'isAuthorized' => $this->isAuthorized,
+                    ]
+                );
+                $this->adapter->save($item);
+            }
+
+            return $header;
+        } catch (\Exception $e) {
+            $this->logger->critical($e->getMessage());
+            $this->revoke();
+        }
+
+        return '';
+    }
+
+    public function revoke(): void
+    {
+        try {
+            if ($this->adapter->hasItem($this->clientId)) {
+                $this->adapter->deleteItem($this->clientId);
+            }
+        } catch (InvalidArgumentException $e) {
+            $this->logger->error($e->getMessage());
+        }
+
+        parent::revoke();
+    }
+}

--- a/src/AuthProvider/CachedSoapProvider.php
+++ b/src/AuthProvider/CachedSoapProvider.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 11:57 AM
+ */
+
+namespace AE\SalesforceRestSdk\AuthProvider;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+use Psr\Cache\InvalidArgumentException;
+
+class CachedSoapProvider extends SoapProvider
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $adapter;
+
+    private const CACHE_KEY = "SOAP_AUTH_";
+
+    public function __construct(
+        CacheItemPoolInterface $adapter,
+        string $username,
+        string $password,
+        string $url = 'https://login.salesforce.com/'
+    ) {
+        parent::__construct($username, $password, $url);
+        $this->adapter = $adapter;
+        $this->logger  = new NullLogger();
+    }
+
+    /**
+     * @return string
+     */
+    private function getCacheKey(): string
+    {
+        return self::CACHE_KEY.$this->username;
+    }
+
+    public function authorize($reauth = false)
+    {
+        $key      = $this->getCacheKey();
+        $oldToken = null;
+
+        try {
+            if (!$reauth && null === $this->token && $this->adapter->hasItem($key)) {
+                $values             = $this->adapter->getItem($key)->get();
+                $this->token        = $oldToken = $values['token'];
+                $this->tokenType    = $values['tokenType'];
+                $this->instanceUrl  = $values['instanceUrl'];
+                $this->identityUrl  = $values['identityUrl'];
+                $this->isAuthorized = $values['isAuthorized'];
+            }
+        } catch (InvalidArgumentException $e) {
+            $this->logger->error($e->getMessage());
+        }
+
+        try {
+            $header = parent::authorize($reauth);
+
+            if ($this->token !== $oldToken) {
+                $item = $this->adapter->getItem($key);
+                $item->set(
+                    [
+                        'token'        => $this->token,
+                        'tokenType'    => $this->tokenType,
+                        'instanceUrl'  => $this->instanceUrl,
+                        'identityUrl'  => $this->identityUrl,
+                        'isAuthorized' => $this->isAuthorized,
+                    ]
+                );
+                $this->adapter->save($item);
+            }
+
+            return $header;
+        } catch (\Exception $e) {
+            $this->logger->critical($e->getMessage());
+            $this->revoke();
+        }
+
+        return '';
+    }
+
+    public function revoke(): void
+    {
+        $key = $this->getCacheKey();
+        try {
+            if ($this->adapter->hasItem($key)) {
+                $this->adapter->deleteItem($key);
+            }
+        } catch (InvalidArgumentException $e) {
+            $this->logger->error($e->getMessage());
+        }
+
+        parent::revoke();
+    }
+}

--- a/src/AuthProvider/OAuthProvider.php
+++ b/src/AuthProvider/OAuthProvider.php
@@ -18,7 +18,7 @@ class OAuthProvider implements AuthProviderInterface
     /**
      * @var bool
      */
-    private $isAuthorized = false;
+    protected $isAuthorized = false;
 
     /**
      * @var string
@@ -63,7 +63,7 @@ class OAuthProvider implements AuthProviderInterface
     /**
      * @var null|string
      */
-    private $instanceUrl;
+    protected $instanceUrl;
 
     /**
      * @var string
@@ -78,12 +78,12 @@ class OAuthProvider implements AuthProviderInterface
     /**
      * @var string|null
      */
-    private $code;
+    protected $code;
 
     /**
      * @var string|null
      */
-    private $identityUrl;
+    protected $identityUrl;
 
     public function __construct(
         string $clientId,
@@ -258,6 +258,22 @@ class OAuthProvider implements AuthProviderInterface
         }
 
         return [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientId(): string
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientSecret(): string
+    {
+        return $this->clientSecret;
     }
 
     /**

--- a/src/AuthProvider/SoapProvider.php
+++ b/src/AuthProvider/SoapProvider.php
@@ -17,7 +17,7 @@ class SoapProvider implements AuthProviderInterface
     /**
      * @var bool
      */
-    private $isAuthorized = false;
+    protected $isAuthorized = false;
 
     /**
      * @var string
@@ -47,12 +47,12 @@ class SoapProvider implements AuthProviderInterface
     /**
      * @var null|string
      */
-    private $instanceUrl;
+    protected $instanceUrl;
 
     /**
      * @var null|string
      */
-    private $identityUrl;
+    protected $identityUrl;
 
     public function __construct(string $username, string $password, string $url = 'https://login.salesforce.com/')
     {

--- a/src/Bayeux/ChannelInterface.php
+++ b/src/Bayeux/ChannelInterface.php
@@ -8,6 +8,8 @@
 
 namespace AE\SalesforceRestSdk\Bayeux;
 
+use AE\SalesforceRestSdk\Bayeux\Extension\ExtensionInterface;
+
 interface ChannelInterface
 {
     public const META             = '/meta';
@@ -23,4 +25,7 @@ interface ChannelInterface
     public function unsubscribe(ConsumerInterface $consumer);
     public function unsubscribeAll();
     public function isMeta();
+    public function addExtension(ExtensionInterface $extension);
+    public function hasExtension(string $name): bool;
+    public function prepareOutgoingMessage(Message $message);
 }

--- a/src/Bayeux/Extension/CachedReplayExtension.php
+++ b/src/Bayeux/Extension/CachedReplayExtension.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 10:49 AM
+ */
+
+namespace AE\SalesforceRestSdk\Bayeux\Extension;
+
+use AE\SalesforceRestSdk\Bayeux\Message;
+use Psr\Cache\CacheItemPoolInterface;
+
+class CachedReplayExtension extends ReplayExtension
+{
+    private const CACHE_PREFIX = "REPLAY_EXT_";
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $adapter;
+
+    public function __construct(CacheItemPoolInterface $adapter, int $replayId = self::REPLAY_NEWEST)
+    {
+        parent::__construct($replayId);
+        $this->adapter = $adapter;
+    }
+
+    public function getReplayIdForChannel(string $channelName)
+    {
+        $key = self::CACHE_PREFIX.preg_replace('/[\{\}\(\)\/\@]+/', '_', $channelName);
+        if ($this->adapter->hasItem($key)) {
+            $cache = $this->adapter->getItem($key)->get();
+            if (is_array($cache) && array_key_exists('timestamp', $cache) && array_key_exists('replayId', $cache)) {
+                $timestamp = \DateTime::createFromFormat(
+                    \DATE_ISO8601,
+                    $cache['timestamp'],
+                    new \DateTimeZone("UTC")
+                );
+                $now       = new \DateTime();
+
+                if (false == $now->diff($timestamp)->days) {
+                    return $cache['replayId'];
+                }
+            }
+        }
+
+        return $this->getReplayId();
+    }
+
+    protected function persistReplayId(Message $message)
+    {
+        $key = self::CACHE_PREFIX.preg_replace('/[\{\}\(\)\/\@]+/', '_', $message->getChannel());
+        $replayId  = $message->getData()->getEvent()->getReplayId();
+        $timestamp = $message->getTimestamp() ?: new \DateTime();
+        $item      = $this->adapter->getItem($key);
+        $item->set(
+            [
+                'replayId'  => $replayId,
+                'timestamp' => $timestamp->format(\DATE_ISO8601),
+            ]
+        );
+        $item->expiresAfter(new \DateInterval('P1D'));
+
+        $this->adapter->save($item);
+    }
+}

--- a/src/Model/Rest/GenericEvent.php
+++ b/src/Model/Rest/GenericEvent.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 1:58 PM
+ */
+
+namespace AE\SalesforceRestSdk\Model\Rest;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class GenericEvent
+{
+    /**
+     * @var string|null
+     * @Serializer\Type("string")
+     */
+    private $payload;
+
+    /**
+     * @var array
+     * @Serializer\Type("array")
+     */
+    private $userIds = [];
+
+    /**
+     * @return null|string
+     */
+    public function getPayload(): ?string
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @param null|string $payload
+     *
+     * @return GenericEvent
+     */
+    public function setPayload(?string $payload): GenericEvent
+    {
+        $this->payload = $payload;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUserIds(): array
+    {
+        return $this->userIds;
+    }
+
+    /**
+     * @param array $userIds
+     *
+     * @return GenericEvent
+     */
+    public function setUserIds(array $userIds): GenericEvent
+    {
+        $this->userIds = $userIds;
+
+        return $this;
+    }
+}

--- a/src/Model/Rest/GenericEvents.php
+++ b/src/Model/Rest/GenericEvents.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 2:00 PM
+ */
+
+namespace AE\SalesforceRestSdk\Model\Rest;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class GenericEvents
+ *
+ * @package AE\SalesforceRestSdk\Model\Rest
+ */
+class GenericEvents
+{
+    /**
+     * @var ArrayCollection|GenericEvent[]
+     * @Serializer\Type("ArrayCollection<AE\SalesforceRestSdk\Model\Rest\GenericEvent>")
+     */
+    private $pushEvents;
+
+    /**
+     * GenericEvents constructor.
+     */
+    public function __construct()
+    {
+        $this->pushEvents = new ArrayCollection();
+    }
+
+    /**
+     * @return GenericEvent[]|ArrayCollection
+     */
+    public function getPushEvents()
+    {
+        return $this->pushEvents;
+    }
+
+    /**
+     * @return GenericEvents
+     */
+    public function clearPushEvents(): GenericEvents
+    {
+        $this->pushEvents->clear();
+
+        return $this;
+    }
+
+    /**
+     * @param GenericEvent $event
+     *
+     * @return GenericEvents
+     */
+    public function addPushEvent(GenericEvent $event): GenericEvents
+    {
+        if (!$this->pushEvents->contains($event)) {
+            $this->pushEvents->add($event);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param GenericEvent $event
+     *
+     * @return GenericEvents
+     */
+    public function removePushEvent(GenericEvent $event): GenericEvents
+    {
+        if ($this->pushEvents->contains($event)) {
+            $this->pushEvents->removeElement($event);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param GenericEvent $event
+     *
+     * @return bool
+     */
+    public function hasPushEvent(GenericEvent $event): bool
+    {
+        return $this->pushEvents->contains($event);
+    }
+}

--- a/src/Model/Rest/StreamingChannelResponse.php
+++ b/src/Model/Rest/StreamingChannelResponse.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 2:46 PM
+ */
+
+namespace AE\SalesforceRestSdk\Model\Rest;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class StreamingChannelResponse
+{
+    /**
+     * @var int|null
+     * @Serializer\Type("int")
+     */
+    private $fanoutCount;
+
+    /**
+     * @var array|null
+     * @Serializer\Type("array")
+     */
+    private $userOnlineStatus = [];
+
+    /**
+     * @return int|null
+     */
+    public function getFanoutCount(): ?int
+    {
+        return $this->fanoutCount;
+    }
+
+    /**
+     * @param int|null $fanoutCount
+     *
+     * @return StreamingChannelResponse
+     */
+    public function setFanoutCount(?int $fanoutCount): StreamingChannelResponse
+    {
+        $this->fanoutCount = $fanoutCount;
+
+        return $this;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getUserOnlineStatus(): ?array
+    {
+        return $this->userOnlineStatus;
+    }
+
+    /**
+     * @param array|null $userOnlineStatus
+     *
+     * @return StreamingChannelResponse
+     */
+    public function setUserOnlineStatus(?array $userOnlineStatus): StreamingChannelResponse
+    {
+        $this->userOnlineStatus = $userOnlineStatus;
+
+        return $this;
+    }
+}

--- a/src/Rest/GenericEventClient.php
+++ b/src/Rest/GenericEventClient.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 3/11/19
+ * Time: 1:41 PM
+ */
+
+namespace AE\SalesforceRestSdk\Rest;
+
+use AE\SalesforceRestSdk\Model\Rest\GenericEvent;
+use AE\SalesforceRestSdk\Model\Rest\GenericEvents;
+use AE\SalesforceRestSdk\Model\Rest\StreamingChannelResponse;
+use AE\SalesforceRestSdk\Rest\SObject\Client;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+
+class GenericEventClient
+{
+    private const CACHE_KEY = "GENERIC_EVENTS";
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    /**
+     * GenericEventClient constructor.
+     *
+     * @param AdapterInterface $adapter
+     * @param Client $client
+     */
+    public function __construct(AdapterInterface $adapter, Client $client)
+    {
+        $this->adapter = $adapter;
+        $this->client  = $client;
+    }
+
+    /**
+     * @param bool $cached
+     *
+     * @return array
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function getStreamingChannelIds($cached = true): array
+    {
+        if ($cached && $this->adapter->hasItem(self::CACHE_KEY)) {
+            return $this->adapter->getItem(self::CACHE_KEY)->get();
+        }
+
+        $result = $this->client->query("SELECT Id, Name FROM StreamingChannel");
+        $records = [];
+
+        do {
+            foreach ($result->getRecords() as $record) {
+                $records[$record->Name] = $record->Id;
+            }
+
+            if (!$result->isDone()) {
+                $result = $this->client->query($result);
+            }
+        } while (!$result->isDone());
+
+        $item = $this->adapter->getItem(self::CACHE_KEY);
+        $item->set($records);
+        $this->adapter->save($item);
+
+        return $records;
+    }
+
+    /**
+     * @param string $channelName
+     * @param bool $cached
+     *
+     * @return null|string
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function getStreamingChannelId(string $channelName, bool $cached = true): ?string
+    {
+        $channels = $this->getStreamingChannelIds($cached);
+
+        if (array_key_exists($channelName, $channels)) {
+            return $channels[$channelName];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $channel
+     * @param GenericEvent $event
+     * @param bool $cached
+     *
+     * @return StreamingChannelResponse|null
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function sendEvent(string $channel, GenericEvent $event, $cached = true): ?StreamingChannelResponse
+    {
+        $channelId = $this->getStreamingChannelId($channel, $cached);
+
+        if (null === $channelId) {
+            return null;
+        }
+
+        $events = new GenericEvents();
+        $events->addPushEvent($event);
+
+        return $this->client->sendGenericEvents($channelId, $events);
+    }
+
+    /**
+     * @param string $channel
+     * @param GenericEvents $events
+     * @param bool $cached
+     *
+     * @return StreamingChannelResponse
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function sendEvents(string $channel, GenericEvents $events, $cached = true): ?StreamingChannelResponse
+    {
+        $channelId = $this->getStreamingChannelId($channel, $cached);
+
+        if (null === $channelId) {
+            return null;
+        }
+
+        return $this->client->sendGenericEvents($channelId, $events);
+    }
+
+    /**
+     * @param string $channel
+     * @param bool $cached
+     *
+     * @return array
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function getChannelSubscribers(string $channel, $cached = true): array
+    {
+        $channelId = $this->getStreamingChannelId($channel, $cached);
+
+        if (null === $channelId) {
+            return [];
+        }
+
+        return $this->client->getStreamingChannelSubscribers($channelId);
+    }
+}


### PR DESCRIPTION
* Allow the ReplayExtension to hold replayIds per channel. Create a CachedReplayExtension which can hold the replayId in cache for 24 hours, in the event the process restarts.

* Create cached auth providers that can hold onto credentials between requests, reducing the number of login requests that need to be made to Salesforce.

* Create a generic event client that piggybacks on the SObject client to send generic events

* Use PSR interfaces to allow for greater adoption.
Update documentation to reflect changes.