### PR TITLE
Curiosity26/cached soap provider fix (#41)

### DIFF
--- a/src/AuthProvider/CachedSoapProvider.php
+++ b/src/AuthProvider/CachedSoapProvider.php
@@ -40,7 +40,7 @@ class CachedSoapProvider extends SoapProvider
      */
     private function getCacheKey(): string
     {
-        return self::CACHE_KEY.$this->username;
+        return self::CACHE_KEY.preg_replace('/[\{\}\(\)\/\@]+/', '_', $this->username);
     }
 
     public function authorize($reauth = false)

--- a/src/Model/Rest/GenericEvent.php
+++ b/src/Model/Rest/GenericEvent.php
@@ -24,6 +24,24 @@ class GenericEvent
      */
     private $userIds = [];
 
+    public function __construct(?string $payload = null, array $userIds = [])
+    {
+        $this->payload = $payload;
+        $this->userIds = $userIds;
+    }
+
+    /**
+     * @param null|string $payload
+     * @param array $userIds
+     *
+     * @return GenericEvent
+     */
+    public static function create(?string $payload = null, array $userIds = []): self
+    {
+        return new static($payload, $userIds);
+    }
+
+
     /**
      * @return null|string
      */

--- a/src/Model/Rest/GenericEvents.php
+++ b/src/Model/Rest/GenericEvents.php
@@ -26,10 +26,22 @@ class GenericEvents
 
     /**
      * GenericEvents constructor.
+     *
+     * @param array $pushEvents
      */
-    public function __construct()
+    public function __construct(array $pushEvents = [])
     {
-        $this->pushEvents = new ArrayCollection();
+        $this->pushEvents = new ArrayCollection($pushEvents);
+    }
+
+    /**
+     * @param array $pushEvents
+     *
+     * @return GenericEvents
+     */
+    public static function create(array $pushEvents = []): self
+    {
+        return new static($pushEvents);
     }
 
     /**


### PR DESCRIPTION
* Clean invalid characters from the cache key

* Add GenericEvent documentation and make it a little easier to create Generic Events