### PR TITLE
Solution for issue #54

### DIFF
--- a/src/Bayeux/Extension/ReplayExtension.php
+++ b/src/Bayeux/Extension/ReplayExtension.php
@@ -77,7 +77,7 @@ class ReplayExtension implements ExtensionInterface
         if ($message->getChannel() === ChannelInterface::META_SUBSCRIBE) {
             $ext = $message->getExt() ?: [];
             $ext[static::NAME] = [
-                $message->getSubscription() => $this->getReplayIdForChannel($message->getChannel()),
+                $message->getSubscription() => $this->getReplayIdForChannel($message->getSubscription()),
             ];
 
             $message->setExt($ext);

--- a/src/Bayeux/Extension/ReplayExtension.php
+++ b/src/Bayeux/Extension/ReplayExtension.php
@@ -75,7 +75,7 @@ class ReplayExtension implements ExtensionInterface
     public function prepareSend(Message $message): void
     {
         if ($message->getChannel() === ChannelInterface::META_SUBSCRIBE) {
-            $ext = $message->getExt() ?: [];
+            $ext               = $message->getExt() ?: [];
             $ext[static::NAME] = [
                 $message->getSubscription() => $this->getReplayIdForChannel($message->getSubscription()),
             ];
@@ -107,7 +107,14 @@ class ReplayExtension implements ExtensionInterface
      */
     protected function persistReplayId(Message $message)
     {
-        $event = $message->getData()->getEvent();
-        $this->setReplayIdForChannel($message->getChannel(), $event->getReplayId());
+        $event       = $message->getData()->getEvent();
+        $channelName = $message->getChannel();
+
+        // Strip the query string, if one exists
+        if (false !== ($pos = strpos($channelName, '?'))) {
+            $channelName = substr($channelName, 0, $pos);
+        }
+
+        $this->setReplayIdForChannel($channelName, $event->getReplayId());
     }
 }

--- a/src/Bayeux/Extension/ReplayExtension.php
+++ b/src/Bayeux/Extension/ReplayExtension.php
@@ -77,7 +77,7 @@ class ReplayExtension implements ExtensionInterface
         if ($message->getChannel() === ChannelInterface::META_SUBSCRIBE) {
             $ext = $message->getExt() ?: [];
             $ext[static::NAME] = [
-                $message->getSubscription() => $this->getReplayIdForChannel($message->getSubscription()),
+                $message->getSubscription() => $this->getReplayIdForChannel($message->getChannel()),
             ];
 
             $message->setExt($ext);
@@ -108,6 +108,6 @@ class ReplayExtension implements ExtensionInterface
     protected function persistReplayId(Message $message)
     {
         $event = $message->getData()->getEvent();
-        $this->dataMap[$message->getChannel()] = $event->getReplayId();
+        $this->setReplayIdForChannel($message->getChannel(), $event->getReplayId());
     }
 }

--- a/src/Bayeux/Extension/ReplayExtension.php
+++ b/src/Bayeux/Extension/ReplayExtension.php
@@ -57,6 +57,19 @@ class ReplayExtension implements ExtensionInterface
     }
 
     /**
+     * @param string $channelName
+     * @param int $replayId
+     *
+     * @return ReplayExtension
+     */
+    public function setReplayIdForChannel(string $channelName, int $replayId = self::REPLAY_NEWEST): self
+    {
+        $this->dataMap[$channelName] = $replayId;
+
+        return $this;
+    }
+
+    /**
      * @param Message $message
      */
     public function prepareSend(Message $message): void


### PR DESCRIPTION
The constructor parameter for the ReplayExtension will apply as the default value for ALL channels. Each channel has their own replay id and most likely won't be in sequence with other channels.

With this change, you can specify a replay ID for a channel:

```php
<?php

$ext = new ReplayExtension(ReplayExtension::REPLAY_NEWEST);
$ext->setReplayIdForChannel('/data/AccountChangeEvent', 841);

$channel->addExtension($ext);
```