### PR TITLE
Extensions on channels must also run when meta connect topic fires

### DIFF
--- a/src/Bayeux/BayeuxClient.php
+++ b/src/Bayeux/BayeuxClient.php
@@ -284,6 +284,9 @@ class BayeuxClient
 
         foreach ($messages as $message) {
             $this->getChannel($message->getChannel())->prepareOutgoingMessage($message);
+            if ($message->getSubscription() && isset($this->channels[$message->getSubscription()])) {
+                $this->getChannel($message->getSubscription())->prepareOutgoingMessage($message);
+            }
         }
 
         try {


### PR DESCRIPTION
Extensions on channels must also fire when the meta channel CONNECT is being ran.  The 'replay' extension might have been applied to a specific channel rather than to all channels.  In the case that a client wide extension fire and then a channel specific extension fires which rely on the same data being manipulated in a particular message, the channel specific extension will override what the client wide extension adds.

(See https://github.com/advisors-excel-llc/salesforce-rest-sdk/issues/75)