### PR TITLE
Streaming Connection Restart glitch

### DIFF
--- a/src/Bayeux/BayeuxClient.php
+++ b/src/Bayeux/BayeuxClient.php
@@ -163,6 +163,7 @@ class BayeuxClient
 
     public function start()
     {
+        $this->previousStates = [];
         $this->setState(new State\HandshakeState($this, $this->logger));
         do {
             $this->state->handle();


### PR DESCRIPTION
Need to clear previous state after a restart (Or just everytime we start).  Disconnect unbinds all of our channel consumers and they will have to be reinstated each iteration.