### PR TITLE
Add error message on SubscribeState

### DIFF
--- a/src/Bayeux/BayeuxClientState/SubscribeState.php
+++ b/src/Bayeux/BayeuxClientState/SubscribeState.php
@@ -18,13 +18,13 @@ class SubscribeState extends ClientState
                             "Failed to subscribe to channel {channel}",
                             [
                                 'channel' => $c->getChannelId(),
+                                'error' => $message->getError(),
                             ]
                         );
                     }
                 }
             )
-        )
-        ;
+        );
     }
 
     public function handle()


### PR DESCRIPTION
I spent a lot of time to debug a problem related to the stored replayid and I found the message inside the `Message` object.
I think it could be very useful to have this message inside the log if it is present.